### PR TITLE
Feature/task 2 completed

### DIFF
--- a/XKCDDemo.DTO/ViewModels/ComicNavigationVM.cs
+++ b/XKCDDemo.DTO/ViewModels/ComicNavigationVM.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace XKCDDemo.DTO.ViewModels
+{
+    public class ComicNavigationVM
+    {
+        public int? PreviousId { get; set; }
+        public int? NextId { get; set; }
+    }
+}

--- a/XKCDDemo.DTO/ViewModels/DisplayedComicVM.cs
+++ b/XKCDDemo.DTO/ViewModels/DisplayedComicVM.cs
@@ -6,6 +6,8 @@ namespace XKCDDemo.DTO.ViewModels
 {
     public class DisplayedComicVM
     {
+        public int? PreviousId { get; set; }
         public ComicDetailVM Comic { get; set; }
+        public int? NextId { get; set; }
     }
 }

--- a/XKCDDemo.Repository/Implementations/ComicRepository.cs
+++ b/XKCDDemo.Repository/Implementations/ComicRepository.cs
@@ -42,5 +42,13 @@ namespace XKCDDemo.Repository.Implementations
                 return null;
             }
         }
+
+        public async Task<int?> GetPreviousComicId(int comicId)
+        {
+            int? firstComicId = await GetFirstComicId();
+            if (firstComicId == null) return null;
+            //The previous comic id will be one id lower than the current comic id;
+            return (comicId - 1 < firstComicId) ? (int?) null : comicId - 1; 
+        }
     }
 }

--- a/XKCDDemo.Repository/Implementations/ComicRepository.cs
+++ b/XKCDDemo.Repository/Implementations/ComicRepository.cs
@@ -25,6 +25,11 @@ namespace XKCDDemo.Repository.Implementations
             }
         }
 
+        public async Task<int?> GetFirstComicId()
+        {
+            return await _api.GetFirstComicId();
+        }
+
         public async Task<int?> GetLastComicId()
         {
             try

--- a/XKCDDemo.Repository/Implementations/ComicRepository.cs
+++ b/XKCDDemo.Repository/Implementations/ComicRepository.cs
@@ -15,14 +15,7 @@ namespace XKCDDemo.Repository.Implementations
         }
         public async Task<ComicDetailVM> GetComicOfTheDay()
         {
-            try
-            {
-                return await _api.GetComicOfTheDay();
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            return await _api.GetComicOfTheDay();
         }
 
         public async Task<int?> GetFirstComicId()
@@ -32,15 +25,7 @@ namespace XKCDDemo.Repository.Implementations
 
         public async Task<int?> GetLastComicId()
         {
-            try
-            {
-                var comic = await _api.GetComicOfTheDay();
-                return comic.Num;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            return (await _api.GetComicOfTheDay())?.Num;
         }
 
         public async Task<int?> GetNextComicId(int comicId)

--- a/XKCDDemo.Repository/Implementations/ComicRepository.cs
+++ b/XKCDDemo.Repository/Implementations/ComicRepository.cs
@@ -43,6 +43,14 @@ namespace XKCDDemo.Repository.Implementations
             }
         }
 
+        public async Task<int?> GetNextComicId(int comicId)
+        {
+            int? lastComicId = await GetLastComicId();
+            if (lastComicId == null) return null;
+            //The next comic id will be one id higher than the current comic id;
+            return (comicId + 1 > lastComicId) ? (int?)null : comicId + 1;
+        }
+
         public async Task<int?> GetPreviousComicId(int comicId)
         {
             int? firstComicId = await GetFirstComicId();

--- a/XKCDDemo.Repository/Implementations/ComicRepository.cs
+++ b/XKCDDemo.Repository/Implementations/ComicRepository.cs
@@ -13,6 +13,12 @@ namespace XKCDDemo.Repository.Implementations
         {
             _api = api;
         }
+
+        public async Task<ComicDetailVM> GetComicById(int comicId)
+        {
+            return await _api.GetComicById(comicId);
+        }
+
         public async Task<ComicDetailVM> GetComicOfTheDay()
         {
             return await _api.GetComicOfTheDay();

--- a/XKCDDemo.Repository/Implementations/XKCDApiHelper.cs
+++ b/XKCDDemo.Repository/Implementations/XKCDApiHelper.cs
@@ -20,19 +20,27 @@ namespace XKCDDemo.Repository.Implementations
             _httpClient.BaseAddress = new Uri("https://xkcd.com/");
         }
 
+        public async Task<ComicDetailVM> GetComicById(int comicId)
+        {
+            try
+            {
+                string endpoint = string.Format("/{0}/info.0.json", comicId);
+                var response = await _httpClient.GetAsync(endpoint);
+                return await ProcessComicRawResponse(response);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
         public async Task<ComicDetailVM> GetComicOfTheDay()
         {
             try
             {
-                var response = await _httpClient.GetAsync("/info.0.json");
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
-                {
-                    var parsedResult = JsonConvert.DeserializeObject<ComicDetailVM>(await response.Content.ReadAsStringAsync());
-                    return parsedResult;
-                } else
-                {
-                    return null;
-                }
+                string endpoint = "/info.0.json";
+                var response = await _httpClient.GetAsync(endpoint);
+                return await ProcessComicRawResponse(response);
             }
             catch (Exception)
             {
@@ -46,5 +54,20 @@ namespace XKCDDemo.Repository.Implementations
             //This is a simulation since by domain knowledge we know the first comic id will be 1
             return Task.Run(()  => (int?)1);
         }
+
+        #region Private methods
+        private async Task<ComicDetailVM> ProcessComicRawResponse(HttpResponseMessage response)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                var parsedResult = JsonConvert.DeserializeObject<ComicDetailVM>(await response.Content.ReadAsStringAsync());
+                return parsedResult;
+            }
+            else
+            {
+                return null;
+            }
+        }
+        #endregion
     }
 }

--- a/XKCDDemo.Repository/Implementations/XKCDApiHelper.cs
+++ b/XKCDDemo.Repository/Implementations/XKCDApiHelper.cs
@@ -9,6 +9,7 @@ using XKCDDemo.Repository.Interfaces;
 
 namespace XKCDDemo.Repository.Implementations
 {
+
     public class XKCDApiHelper : IXKCDApi
     {
         private readonly HttpClient _httpClient;
@@ -37,6 +38,13 @@ namespace XKCDDemo.Repository.Implementations
             {
                 return null;
             }
+        }
+
+        //Eventually if the api chances and it adds an endpoint to get the initial value id, the only change needed would be here so we keep the repository agnostic of this knowledge
+        public Task<int?> GetFirstComicId()
+        {
+            //This is a simulation since by domain knowledge we know the first comic id will be 1
+            return Task.Run(()  => (int?)1);
         }
     }
 }

--- a/XKCDDemo.Repository/Interfaces/IComicRepository.cs
+++ b/XKCDDemo.Repository/Interfaces/IComicRepository.cs
@@ -11,5 +11,6 @@ namespace XKCDDemo.Repository.Interfaces
         Task<ComicDetailVM> GetComicOfTheDay();
         Task<int?> GetLastComicId();
         Task<int?> GetFirstComicId();
+        Task<int?> GetPreviousComicId(int comicId);
     }
 }

--- a/XKCDDemo.Repository/Interfaces/IComicRepository.cs
+++ b/XKCDDemo.Repository/Interfaces/IComicRepository.cs
@@ -12,5 +12,6 @@ namespace XKCDDemo.Repository.Interfaces
         Task<int?> GetLastComicId();
         Task<int?> GetFirstComicId();
         Task<int?> GetPreviousComicId(int comicId);
+        Task<int?> GetNextComicId(int comicId);
     }
 }

--- a/XKCDDemo.Repository/Interfaces/IComicRepository.cs
+++ b/XKCDDemo.Repository/Interfaces/IComicRepository.cs
@@ -10,5 +10,6 @@ namespace XKCDDemo.Repository.Interfaces
     {
         Task<ComicDetailVM> GetComicOfTheDay();
         Task<int?> GetLastComicId();
+        Task<int?> GetFirstComicId();
     }
 }

--- a/XKCDDemo.Repository/Interfaces/IComicRepository.cs
+++ b/XKCDDemo.Repository/Interfaces/IComicRepository.cs
@@ -13,5 +13,6 @@ namespace XKCDDemo.Repository.Interfaces
         Task<int?> GetFirstComicId();
         Task<int?> GetPreviousComicId(int comicId);
         Task<int?> GetNextComicId(int comicId);
+        Task<ComicDetailVM> GetComicById(int comicId);
     }
 }

--- a/XKCDDemo.Repository/Interfaces/IXKCDApi.cs
+++ b/XKCDDemo.Repository/Interfaces/IXKCDApi.cs
@@ -7,5 +7,6 @@ namespace XKCDDemo.Repository.Interfaces
     {
         //[Get("/info.0.json")]
         Task<ComicDetailVM> GetComicOfTheDay();
+        Task<int?> GetFirstComicId();
     }
 }

--- a/XKCDDemo.Repository/Interfaces/IXKCDApi.cs
+++ b/XKCDDemo.Repository/Interfaces/IXKCDApi.cs
@@ -7,6 +7,7 @@ namespace XKCDDemo.Repository.Interfaces
     {
         //[Get("/info.0.json")]
         Task<ComicDetailVM> GetComicOfTheDay();
+        Task<ComicDetailVM> GetComicById(int comicId);
         Task<int?> GetFirstComicId();
     }
 }

--- a/XKCDDemo.Service/Implementations/ComicService.cs
+++ b/XKCDDemo.Service/Implementations/ComicService.cs
@@ -30,9 +30,12 @@ namespace XKCDDemo.Service.Implementations
         public async Task<DisplayedComicVM> GetComicOfTheDay()
         {
             var comicOfTheDay = await _comicRepository.GetComicOfTheDay();
+            var comicNavigationContext = await GetComicNavigationById(comicOfTheDay?.Num);
             return new DisplayedComicVM
             {
-                Comic = comicOfTheDay
+                Comic = comicOfTheDay,
+                PreviousId = comicNavigationContext?.PreviousId,
+                NextId = comicNavigationContext?.NextId
             };
         }
     }

--- a/XKCDDemo.Service/Implementations/ComicService.cs
+++ b/XKCDDemo.Service/Implementations/ComicService.cs
@@ -17,6 +17,18 @@ namespace XKCDDemo.Service.Implementations
             _comicRepository = comicRepository;
         }
 
+        public async Task<DisplayedComicVM> GetComicDetailById(int comicId)
+        {
+            var comic = await _comicRepository.GetComicById(comicId);
+            var comicNavigationContext = await GetComicNavigationById(comic?.Num);
+            return new DisplayedComicVM
+            {
+                Comic = comic,
+                PreviousId = comicNavigationContext?.PreviousId,
+                NextId = comicNavigationContext?.NextId
+            };
+        }
+
         public async Task<ComicNavigationVM> GetComicNavigationById(int? comicId)
         {
             if (comicId == null) return new ComicNavigationVM { NextId = null, PreviousId = null };

--- a/XKCDDemo.Service/Implementations/ComicService.cs
+++ b/XKCDDemo.Service/Implementations/ComicService.cs
@@ -16,6 +16,17 @@ namespace XKCDDemo.Service.Implementations
         {
             _comicRepository = comicRepository;
         }
+
+        public async Task<ComicNavigationVM> GetComicNavigationById(int? comicId)
+        {
+            if (comicId == null) return new ComicNavigationVM { NextId = null, PreviousId = null };
+            return new ComicNavigationVM
+            {
+                PreviousId = await _comicRepository.GetPreviousComicId(comicId.Value),
+                NextId = await _comicRepository.GetNextComicId(comicId.Value)
+            };
+        }
+
         public async Task<DisplayedComicVM> GetComicOfTheDay()
         {
             var comicOfTheDay = await _comicRepository.GetComicOfTheDay();

--- a/XKCDDemo.Service/Interfaces/IComicService.cs
+++ b/XKCDDemo.Service/Interfaces/IComicService.cs
@@ -9,6 +9,8 @@ namespace XKCDDemo.Service.Interfaces
     public interface IComicService
     {
         Task<DisplayedComicVM> GetComicOfTheDay();
+        Task<DisplayedComicVM> GetComicDetailById(int comicId);
+
         Task<ComicNavigationVM> GetComicNavigationById(int? comicId);
     }
 }

--- a/XKCDDemo.Service/Interfaces/IComicService.cs
+++ b/XKCDDemo.Service/Interfaces/IComicService.cs
@@ -9,5 +9,6 @@ namespace XKCDDemo.Service.Interfaces
     public interface IComicService
     {
         Task<DisplayedComicVM> GetComicOfTheDay();
+        Task<ComicNavigationVM> GetComicNavigationById(int? comicId);
     }
 }

--- a/XKCDDemo.Web/Controllers/ComicController.cs
+++ b/XKCDDemo.Web/Controllers/ComicController.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using XKCDDemo.Service.Interfaces;
+
+namespace XKCDDemo.Web.Controllers
+{
+    [Route("comic")]
+    public class ComicController : Controller
+    {
+        private readonly IComicService _comicService;
+
+        public ComicController(IComicService comicService)
+        {
+            _comicService = comicService;
+        }
+
+        [Route("{id}")]
+        public async Task<IActionResult> Detail([FromRoute]int id)
+        {
+            var detail = await _comicService.GetComicDetailById(id);
+            return View(detail);
+        }
+    }
+}

--- a/XKCDDemo.Web/Controllers/ComicController.cs
+++ b/XKCDDemo.Web/Controllers/ComicController.cs
@@ -21,6 +21,10 @@ namespace XKCDDemo.Web.Controllers
         public async Task<IActionResult> Detail([FromRoute]int id)
         {
             var detail = await _comicService.GetComicDetailById(id);
+            if (detail?.Comic == null)
+            {
+                return RedirectToAction("Index", "Home");
+            }
             return View(detail);
         }
     }

--- a/XKCDDemo.Web/Views/Comic/Detail.cshtml
+++ b/XKCDDemo.Web/Views/Comic/Detail.cshtml
@@ -1,0 +1,6 @@
+﻿@model DisplayedComicVM
+@{
+    ViewData["Title"] = $"Comic - {Model?.Comic?.SafeTitle}";
+}
+<partial name="_ComicDetailPartial" model="@Model"/>
+

--- a/XKCDDemo.Web/Views/Home/Index.cshtml
+++ b/XKCDDemo.Web/Views/Home/Index.cshtml
@@ -3,13 +3,4 @@
     ViewData["Title"] = "Comic of the day";
 }
 
-<div class="row">
-    <div class="col-12">
-        <div class="text-center">
-            <h3>@Model?.Comic?.Title</h3>
-            <img class="img-fluid" alt="@Model?.Comic?.Alt" src="@Model?.Comic?.Img" /><br /><br />
-            <p>@Model?.Comic?.Alt</p>
-        </div>
-    </div>
-</div>
-
+<partial name="_ComicDetailPartial" model="@Model" />

--- a/XKCDDemo.Web/Views/Shared/_ComicDetailPartial.cshtml
+++ b/XKCDDemo.Web/Views/Shared/_ComicDetailPartial.cshtml
@@ -7,5 +7,15 @@
             <img class="img-fluid" alt="@Model?.Comic?.Alt" src="@Model?.Comic?.Img" /><br /><br />
             <p>@Model?.Comic?.Alt</p>
         </div>
+        <div class="text-center">
+            @if (Model?.PreviousId != null)
+            {
+                <a href="/comic/@Model.PreviousId">Previous</a>
+            }
+            @if (Model?.NextId != null)
+            {
+                <a href="/comic/@Model.NextId">Next</a>
+            }
+        </div>
     </div>
 </div>

--- a/XKCDDemo.Web/Views/Shared/_ComicDetailPartial.cshtml
+++ b/XKCDDemo.Web/Views/Shared/_ComicDetailPartial.cshtml
@@ -1,0 +1,11 @@
+﻿@model DisplayedComicVM
+
+<div class="row">
+    <div class="col-12">
+        <div class="text-center">
+            <h3>@Model?.Comic?.Title</h3>
+            <img class="img-fluid" alt="@Model?.Comic?.Alt" src="@Model?.Comic?.Img" /><br /><br />
+            <p>@Model?.Comic?.Alt</p>
+        </div>
+    </div>
+</div>

--- a/XKCDDemo.Web/Views/Shared/_Layout.cshtml
+++ b/XKCDDemo.Web/Views/Shared/_Layout.cshtml
@@ -19,7 +19,7 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Comic of the Day</a>
                         </li>
                     </ul>
                 </div>

--- a/XKCDDemo.Web/XKCDDemo.Web.csproj
+++ b/XKCDDemo.Web/XKCDDemo.Web.csproj
@@ -10,4 +10,14 @@
     <ProjectReference Include="..\XKCDDemo.Service\XKCDDemo.Service.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Implemented endpoint consumption to get comic detail by specifying the id.
- Refactored the api communication layer to use c# HttpClient instead of third party library in the server side code.
- Implemented service layer to handle the fetch of the comic detail and the fetch of the navigation context for that specific comic, as well as for the comic of the day.
- Implemented new view and route ("comic/XXX") for showing comic detail by id and added the "previous and next" button validation"
- Validated that when viewing the comic of the day it only displays the previous button:
![image](https://user-images.githubusercontent.com/11896145/69003574-4b6be680-08ca-11ea-97b0-3cb6ce9b8b1f.png)

- Validated that when viewing the first comic it only displays the next button
![image](https://user-images.githubusercontent.com/11896145/69003626-29269880-08cb-11ea-8166-ec309e41e900.png)

- Validated that when viewing a midpoint comic it displays both if available.
![image](https://user-images.githubusercontent.com/11896145/69003597-8706b080-08ca-11ea-908c-d058739b10f2.png)

- Implemented that in case that a comic is not found, it automatically redirects to the comic of the day page.
![image](https://user-images.githubusercontent.com/11896145/69003598-9c7bda80-08ca-11ea-94b1-a1c1889c995e.png)
![image](https://user-images.githubusercontent.com/11896145/69003600-ad2c5080-08ca-11ea-87dc-0ad36416f30e.png)
